### PR TITLE
fix expectDoesNotThrow

### DIFF
--- a/Tests/UTF8StringTests/StdlibUnittestShims.swift
+++ b/Tests/UTF8StringTests/StdlibUnittestShims.swift
@@ -40,21 +40,21 @@ public func expectFalse(
   XCTAssertFalse(try expression1(), file: file, line: line)
 }
 
-public func expectDoesNotThrow<T>(
-  _ expression1: @autoclosure () throws -> T,
+public func expectDoesNotThrow(
+  _ expression1: () throws -> Void,
   file: StaticString = #file, line: UInt = #line
   ) {
-  XCTAssertNoThrow(expression1, file: file, line: line)
+  XCTAssertNoThrow(try expression1(), file: file, line: line)
 }
 
 
-public func expectThrows<T, E: Error>(
+public func expectThrows<E: Error>(
   _ err: E,
-  _ expression1: () throws -> T,
+  _ expression1: () throws -> Void,
   file: StaticString = #file, line: UInt = #line
   ) where E: Equatable {
   do {
-    try _ = expression1()
+    try expression1()
     XCTFail("no throw", file: file, line: line)
   } catch {
     guard let e = error as? E else {


### PR DESCRIPTION
- `expectDoesNotThrow` was `@autoclosure () throws -> T`
- `expectThrows      ` was `() throws -> T`

but both were called with an explicit closure. That had the really bad
effect that `T` in `expectDoesNotThrow` just became the _function_ type
but obviously we were never actually running that function as its real
type was lost.

There are basically two ways out of this and I implemented them both:

- both functions should take closures that return `Void`, not `T`. The
  value is lost anyway (due to `XCTAssertNoThrow` just throwing it away).
- whether the functions should take `@autoclosure` or not is up to
  debate. Because they were all called with explicit closures I opted
  for no autoclosures.

Summary: `() -> T` + `@autoclosure`  + ignoring the T (as `XCTAssertNoThrow` does) = desaster
as `T` can become a thunk that produces the type that the programmer
expects `T` to be.